### PR TITLE
Use assertContains instead of strpos

### DIFF
--- a/tests/Integration/HelloCommandTest.php
+++ b/tests/Integration/HelloCommandTest.php
@@ -12,6 +12,6 @@ class HelloCommandTest extends TestCase
     {
         $this->app->call((new HelloCommand())->getName());
 
-        $this->assertTrue(strpos($this->app->output(), 'Love beautiful code? We do too.') !== false);
+        $this->assertContains('Love beautiful code? We do too.', $this->app->output());
     }
 }


### PR DESCRIPTION
I've used `assertContains` instead of `strpos`. Besides is a lot more clear, it will give us a better error message in case it fails :nerd_face: 