### PR TITLE
Replace Box compactors with recommended ones

### DIFF
--- a/box.json
+++ b/box.json
@@ -12,7 +12,7 @@
     "exclude-composer-files": false,
     "compression": "GZ",
     "compactors": [
-        "Herrera\\Box\\Compactor\\Php",
-        "Herrera\\Box\\Compactor\\Json"
+        "KevinGH\\Box\\Compactor\\Php",
+        "KevinGH\\Box\\Compactor\\Json"
     ]
 }


### PR DESCRIPTION
When running the build process in verbose mode you get the following recommendations.

```
- The compactor "Herrera\Box\Compactor\Php" has been deprecated, use "KevinGH\Box\Compactor\Php" instead.
- The compactor "Herrera\Box\Compactor\Json" has been deprecated, use "KevinGH\Box\Compactor\Json" instead.
```