### PR TITLE
Add example unit test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,9 @@
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <listeners>
         <listener class="NunoMaduro\Collision\Adapters\Phpunit\Listener"/>

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class ExampleTest extends TestCase
+{
+    /**
+     * A basic test example.
+     *
+     * @return void
+     */
+    public function testBasicTest()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR registers a test suite by default for unit tests and also adds an example test.

I had to add this myself for my Zero app and it took some trial and error. I originally tried putting unit tests in `./tests` but then my unit test suite included all the feature tests too.

I'm using unit tests for some of the more complex logic that isn't contained directly in a command class.

Adding this by default should make it easier to get started with Zero and if you don't need it you can just delete the example.