### PR TITLE
gitignore builds folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 /.vscode
 /.vagrant
+/builds


### PR DESCRIPTION
Currently Zero doesn't ignore builds by default. This PR updates the `.gitignore` to ignore the `builds` folder.

I personally don't commit the `builds` folder because it's a rather large file (~4mb) that is easily built from source and doesn't ever need to be edited manually. Adding it to git just makes checkout slower and clutters up the history.

Another major downside is git won't show a diff by default and it's easy to miss changes to it. If you do realize it changed and try to review it it's going to be very difficult. If someone accidentally edits the phar in a find and replace or intentionally adds malicious code it's easy to miss.

The other projects I looked at (php-cs-fixer, phpunit, composer, etc) are also not committing the phar to version control.

The simplest alternative if you are using Github is to [attach the phar to a release](https://help.github.com/en/articles/creating-releases). It might be nice to add a note to the docs about this.