### PR TITLE
Require laravel-zero/framework >= 5.8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "laravel-zero/framework": "5.8.*"
+        "laravel-zero/framework": "5.8.* >= 5.8.4"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This prevents installing incompatible versions of illuminate/contracts and nunomaduro/collision.

Closes #224.

See https://getcomposer.org/doc/articles/versions.md#writing-version-constraints for an explanation of the constraints.

> By using comparison operators you can specify ranges of valid versions. Valid operators are >, >=, <, <=, !=.
> Ranges separated by a space ( ) or comma (,) will be treated as a logical AND