### PR TITLE
Add the event service provider

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        //
+    ];
+
+    /**
+     * The subscriber classes to register.
+     *
+     * @var array
+     */
+    protected $subscribe = [
+        //
+    ];
+
+    /**
+     * Register any events for your application.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+
+        //
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -54,6 +54,7 @@ return [
 
     'providers' => [
         App\Providers\AppServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
     ],
 
 ];


### PR DESCRIPTION
This PR sets up the event service provider by default so it's easier to use events in your Zero application.

I've found the events to be really useful, especially the `ArtisanStarting`, `CommandStarting`, and `CommandFinished` events emitted by the Artisan console. To start using the events I had to manually copy the service provider from a Laravel app and set everything up. I think it would be helpful if this was setup by default.

If you want to keep Zero lightweight and exclude this I understand. In that case would it make sense to publish this from a component, or maybe just add a page to the docs?