### PR TITLE
Fix StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,3 @@
 preset: laravel
-enabled:
-  - alpha_ordered_imports
 disabled:
-  - length_ordered_imports
   - self_accessor


### PR DESCRIPTION
This continues from #245, where alpha-ordered imports were introduced.

However, as this is now the default in the Laravel preset, it will currently return a configuration error without this fix (see laravel-zero/framework#368 for the corresponding PR on the framework).