### PR TITLE
Update to use 'app.env' for environment

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -35,11 +35,11 @@ return [
     |
     | This value determines the "environment" your application is currently
     | running in. This may determine how you prefer to configure various
-    | services the application utilizes. Set this in your ".env" file.
+    | services the application utilizes.
     |
     */
 
-    'env' => env('APP_ENV', 'production'),
+    'env' => 'development',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -35,7 +35,8 @@ return [
     |
     | This value determines the "environment" your application is currently
     | running in. This may determine how you prefer to configure various
-    | services the application utilizes.
+    | services the application utilizes. This can be overridden using
+    | the global command line "--env" option when calling commands.
     |
     */
 

--- a/config/app.php
+++ b/config/app.php
@@ -35,11 +35,11 @@ return [
     |
     | This value determines the "environment" your application is currently
     | running in. This may determine how you prefer to configure various
-    | services your application utilizes. Should be true in production.
+    | services the application utilizes. Set this in your ".env" file.
     |
     */
 
-    'production' => false,
+    'env' => env('APP_ENV', 'production'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This updates to allow using `app.env` for choosing the environment of the application. It defaults to `development`, which matches the previous behaviour.

---

See https://github.com/laravel-zero/framework/pull/378 for more details.