### PR TITLE
Remove printerClass

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
          stopOnFailure="false">
     <testsuites>
         <testsuite name="Feature">


### PR DESCRIPTION
Right now we're having the same output running `./vendor/bin/phpunit` and `./application test`, with this makes we have the same behaviour as Laravel:

![image](https://user-images.githubusercontent.com/347400/76563315-eabe7600-6485-11ea-996a-f132554f30bd.png)
