### PR TITLE
Removing post-create-project-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,6 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-    "scripts": {
-        "post-create-project-cmd": [
-            "@php application app:rename"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": ["application"]


### PR DESCRIPTION
Removing post-create-project-cmd to prevent "Script @php application app:rename handling the post-create-project-cmd event returned with error code 1"