### PR TITLE
Removing license link from readme (#316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ For full documentation, visit [laravel-zero.com](https://laravel-zero.com/).
 
 ## License
 
-Laravel Zero is an open-source software licensed under the [MIT license](https://github.com/laravel-zero/laravel-zero/blob/stable/LICENSE.md).
+Laravel Zero is an open-source software licensed under the MIT license.


### PR DESCRIPTION
In relation to #316 - removing the link pointing nowhere.