### PR TITLE
Change the permissions of the file /laravel-zero/framework/bin/box to 0555 to make it executable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
             "Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "post-create-project-cmd": [
+            "@php -r \"chmod('vendor/laravel-zero/framework/bin/box', 0555)\""
+        ]
+    }
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,


### PR DESCRIPTION
in the previous version this problem didn't appear and there was no error when running the command ```app:build```, but I tried to install laravel-zero to the latest version and I got an error message that ./box doesn't have execute permission, I tried to change the file permission to 0555 and my app runs smoothly without getting any error message. Maybe everyone will be annoyed if they don't know about this misconfiguration, so I want to change the contents of the composer.json file which if anyone wants to create a new project, the ./box file will automatically change the permissions to 0555.