### PR TITLE
Fix grammatical omission of 'of' on line 14

### DIFF
--- a/application
+++ b/application
@@ -11,7 +11,7 @@ define('LARAVEL_START', microtime(true));
 | Composer provides a convenient, automatically generated class loader
 | for our application. We just need to utilize it! We'll require it
 | into the script here so that we do not have to worry about the
-| loading of any our classes "manually". Feels great to relax.
+| loading of any of our classes manually. It's great to relax.
 |
 */
 


### PR DESCRIPTION
Fix grammatical omission of 'of' on line 14, and updates the wording so that the line length is still nicely formatted.

This fix is directly taken from https://github.com/laravel/laravel/pull/5603.

An alternate version which I think looks nicer is:

    | loading of our classes manually. It feels great to relax.

But I picked the option that Laravel has for consistency. 