### PR TITLE
Fix link to Standalone Compiler documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Laravel Zero was created by [Nuno Maduro](https://github.com/nunomaduro) and [Ow
 - Built on top of the [Laravel](https://laravel.com) components.
 - Optional installation of Laravel [Eloquent](https://laravel-zero.com/docs/database/), Laravel [Logging](https://laravel-zero.com/docs/logging/) and many others.
 - Supports interactive [menus](https://laravel-zero.com/docs/build-interactive-menus/) and [desktop notifications](https://laravel-zero.com/docs/send-desktop-notifications/) on Linux, Windows & MacOS.
-- Ships with a [Scheduler](https://laravel-zero.com/docs/task-scheduling/) and  a [Standalone Compiler](https://laravel-zero.com/docs/build-a-standalone-application/).
+- Ships with a [Scheduler](https://laravel-zero.com/docs/task-scheduling/) and  a [Standalone Compiler](https://laravel-zero.com/docs/distribute-as-a-single-executable-binary/).
 - Integration with [Collision](https://github.com/nunomaduro/collision) - Beautiful error reporting
 - Follow the creator Nuno Maduro:
     - YouTube: **[youtube.com/@nunomaduro](https://www.youtube.com/@nunomaduro)** — Videos every weekday


### PR DESCRIPTION
There is a 404 error under Standalone Compiler link in Readme. I think https://laravel-zero.com/docs/distribute-as-a-single-executable-binary/ is the right one