### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
         git config --global core.eol lf
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: ${{ matrix.php }}
         extensions: fileinfo


### PR DESCRIPTION
Pins every `uses:` reference in this repo's GitHub Actions workflows to a
commit SHA, preserving the original tag as an inline comment so Dependabot can
keep bumping it.

Rewrites:

  - `actions/checkout@v3` → `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744` (in `.github/workflows/tests.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/tests.yml`)

This mitigates supply-chain risk from compromised action tag/branch refs and
makes future Dependabot PRs update the SHA in place (rather than only bumping
tags).